### PR TITLE
Add Unity X180T support and require deploy.sh host argument

### DIFF
--- a/custom_components/ha_onecontrol/__init__.py
+++ b/custom_components/ha_onecontrol/__init__.py
@@ -9,7 +9,13 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .const import DOMAIN
+from .const import (
+    CONF_BLUETOOTH_PIN,
+    CONF_GATEWAY_FAMILY,
+    CONF_PAIRING_METHOD,
+    GATEWAY_FAMILY_X180T,
+    DOMAIN,
+)
 from .coordinator import OneControlCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,7 +38,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.version,
     )
 
-    if entry.version == 1:
+    version = entry.version
+
+    if version == 1:
         # v1→v2: drop table_id from device entity unique_ids.
         # Old format: {mac12hex}_{type}_{table:02x}{device:02x}
         # New format: {mac12hex}_{type}_{device:02x}
@@ -88,6 +96,33 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.info(
             "Migration of OneControl entry %s to version 2 complete", entry.entry_id
         )
+        version = 2
+
+    if version == 2:
+        if (
+            entry.data.get(CONF_GATEWAY_FAMILY) == GATEWAY_FAMILY_X180T
+            and entry.data.get(CONF_PAIRING_METHOD) != "pin"
+            and CONF_BLUETOOTH_PIN in entry.data
+        ):
+            new_data = {
+                key: value
+                for key, value in entry.data.items()
+                if key != CONF_BLUETOOTH_PIN
+            }
+            hass.config_entries.async_update_entry(
+                entry,
+                data=new_data,
+                version=3,
+            )
+            _LOGGER.info(
+                "Migrated X180T push-button entry %s by removing stale bluetooth_pin",
+                entry.entry_id,
+            )
+        else:
+            hass.config_entries.async_update_entry(entry, version=3)
+            _LOGGER.info(
+                "Migration of OneControl entry %s to version 3 complete", entry.entry_id
+            )
 
     return True
 

--- a/custom_components/ha_onecontrol/__init__.py
+++ b/custom_components/ha_onecontrol/__init__.py
@@ -118,11 +118,39 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 "Migrated X180T push-button entry %s by removing stale bluetooth_pin",
                 entry.entry_id,
             )
+            version = 3
         else:
             hass.config_entries.async_update_entry(entry, version=3)
             _LOGGER.info(
                 "Migration of OneControl entry %s to version 3 complete", entry.entry_id
             )
+            version = 3
+
+    if version == 3:
+        ent_reg = er.async_get(hass)
+        entries = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+        cover_sensor_pattern = re.compile(r"^([0-9a-f]{12})_cover_([0-9a-f]{2})$")
+
+        for ent in entries:
+            if ent.domain != "sensor":
+                continue
+            match = cover_sensor_pattern.match(ent.unique_id or "")
+            if not match:
+                continue
+            mac, device = match.groups()
+            new_unique_id = f"{mac}_cover_state_{device}"
+            ent_reg.async_update_entity(ent.entity_id, new_unique_id=new_unique_id)
+            _LOGGER.info(
+                "Migration: renamed cover sensor %s → %s",
+                ent.unique_id,
+                new_unique_id,
+            )
+
+        hass.config_entries.async_update_entry(entry, version=4)
+        _LOGGER.info(
+            "Migration of OneControl entry %s to version 4 complete", entry.entry_id
+        )
+        version = 4
 
     return True
 

--- a/custom_components/ha_onecontrol/config_flow.py
+++ b/custom_components/ha_onecontrol/config_flow.py
@@ -243,8 +243,6 @@ class OneControlConfigFlow(ConfigFlow, domain=DOMAIN):
             fields = {}
             if self._pairing_method == PairingMethod.PIN:
                 fields[vol.Required(CONF_BLUETOOTH_PIN)] = str
-            else:
-                fields[vol.Optional(CONF_BLUETOOTH_PIN, default="")] = str
             step_id = "confirm_x180t"
         elif self._pairing_method == PairingMethod.PIN:
             fields[vol.Optional(CONF_BLUETOOTH_PIN, default="")] = str

--- a/custom_components/ha_onecontrol/const.py
+++ b/custom_components/ha_onecontrol/const.py
@@ -82,6 +82,7 @@ EVENT_HOUR_METER = 0x0F
 EVENT_LEVELER = 0x10
 EVENT_SESSION_STATUS = 0x1A
 EVENT_TANK_SENSOR_V2 = 0x1B
+EVENT_TANK_ALERT = 0x1C
 EVENT_REAL_TIME_CLOCK = 0x20
 
 # ---------------------------------------------------------------------------

--- a/custom_components/ha_onecontrol/coordinator.py
+++ b/custom_components/ha_onecontrol/coordinator.py
@@ -2342,7 +2342,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Keep CAN-only BLE links active during idle windows.
 
         Some CAN-only gateways drop idle BLE links quickly unless periodic
-        host traffic is present. Send keepalive frames every 30 seconds to keep
+        host traffic is present. Send keepalive frames every 3 seconds to keep
         the link alive and establish baseline connectivity.
         """
         try:
@@ -2358,7 +2358,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     await self._advertise_can_local_host_identity(
                         client, reason="keepalive-initial", force=False
                     )
-                    await self._send_can_keepalive_status(client)
+                    await self._send_can_device_discovery(client)
                 except Exception as exc:
                     _LOGGER.warning("CAN BLE: initial keepalive failed: %s", exc)
             
@@ -2369,8 +2369,8 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 and self._can_read_subscribed
                 and self._client is client
             ):
-                # Longer interval (30s) to keep connection alive without excessive traffic
-                await asyncio.sleep(30.0)
+                # Shorter interval (3s) to keep connection alive with periodic discovery traffic
+                await asyncio.sleep(3.0)
                 if not (
                     self._connected
                     and self._authenticated
@@ -2392,7 +2392,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     await self._advertise_can_local_host_identity(
                         client, reason="keepalive", force=False
                     )
-                    await self._send_can_keepalive_status(client)
+                    await self._send_can_device_discovery(client)
                 except Exception as exc:
                     _LOGGER.warning("CAN BLE: keepalive tick failed: %s", exc)
                     # Don't break; let normal disconnect handling deal with it

--- a/custom_components/ha_onecontrol/coordinator.py
+++ b/custom_components/ha_onecontrol/coordinator.py
@@ -1817,8 +1817,9 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await asyncio.sleep(0.5)
                 verify = await client.read_gatt_char(UNLOCK_STATUS_CHAR_UUID)
                 _LOGGER.debug("CAN BLE: key/seed unlock verify=%s", verify.hex())
-                # Check if unlock succeeded (should be "unlocked" or non-zero)
-                if verify.lower() == b"unlocked" or (len(verify) > 0 and verify[0] != 0x00):
+                # Only accept explicit unlocked status values to avoid false positives
+                # from textual or status-style responses.
+                if verify.lower() == b"unlocked" or verify == b"\x01":
                     unlock_success = True
                     _LOGGER.debug("CAN BLE: key/seed unlock successful")
                 else:
@@ -3703,7 +3704,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # For CAN BLE gateways, add extra delay on first reconnect to let BlueZ settle
         # after the disconnect. CAN BLE disconnects can leave BlueZ in "InProgress" state
         # if we reconnect too quickly.
-        if self._can_ble_confirmed and self._consecutive_failures == 1:
+        if self._can_ble_confirmed and self._consecutive_failures == 0:
             delay = 2.0  # Give BlueZ 2s to clean up after CAN BLE disconnect
             _LOGGER.debug(
                 "CAN BLE disconnect detected — delaying reconnect by %.1fs to allow BlueZ cleanup",

--- a/custom_components/ha_onecontrol/coordinator.py
+++ b/custom_components/ha_onecontrol/coordinator.py
@@ -103,11 +103,13 @@ from .protocol.events import (
     GeneratorStatus,
     HourMeter,
     HvacZone,
+    LevelerStatus,
     RealTimeClock,
     RelayStatus,
     RgbLight,
     RvStatus,
     SystemLockout,
+    TankAlert,
     TankLevel,
     parse_event,
     parse_metadata_response,
@@ -115,7 +117,9 @@ from .protocol.events import (
 from .protocol.dtc_codes import get_name as dtc_get_name, is_fault as dtc_is_fault
 from .protocol.function_names import get_friendly_name
 from .protocol.tea import (
+    CAN_BLE_KEY_SEED_CIPHER,
     RC_CYPHER,
+    X180T_KEY_SEED_CIPHER,
     calculate_can_ble_key_seed_key,
     calculate_step1_key,
     calculate_step2_key,
@@ -307,9 +311,18 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._instance_tag: str = f"{id(self):x}"[-6:]
         # Android uses gateway_pin for both BLE bonding AND protocol auth.
         # bluetooth_pin is an optional override if the BLE PIN differs.
+        # For X180T, BLE pairing is Just Works, so don't use gateway_pin as bluetooth_pin
+        bluetooth_pin_default = "" if self._gateway_family == GATEWAY_FAMILY_X180T else self.gateway_pin
         self._bluetooth_pin: str = entry.data.get(
-            CONF_BLUETOOTH_PIN, ""
-        ) or self.gateway_pin
+            CONF_BLUETOOTH_PIN, bluetooth_pin_default
+        )
+        if self.is_x180t_gateway and self._pairing_method != "pin":
+            if self._bluetooth_pin:
+                _LOGGER.warning(
+                    "X180T push-button gateway %s ignoring configured bluetooth_pin; using Just Works pairing",
+                    self.address,
+                )
+            self._bluetooth_pin = ""
         self._pin_agent_ctx: PinAgentContext | None = None  # active D-Bus agent context
         self._pin_dbus_succeeded: bool = False  # bonding completed this session
         self._pin_already_bonded: bool = False  # BlueZ "already bonded" seen (sticky — not reset on disconnect)
@@ -426,6 +439,8 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_locks: dict[str, DeviceLock] = {}
         self.generators: dict[str, GeneratorStatus] = {}
         self.hour_meters: dict[str, HourMeter] = {}
+        self.levelers: dict[str, LevelerStatus] = {}
+        self.tank_alerts: dict[str, TankAlert] = {}
         self.rtc: RealTimeClock | None = None
         self.system_lockout_level: int | None = None
 
@@ -1132,7 +1147,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         for status_dict in (
             self.relays, self.dimmable_lights, self.rgb_lights, self.covers,
             self.hvac_zones, self.tanks, self.device_online, self.device_locks,
-            self.generators, self.hour_meters, self.unknown_devices,
+            self.generators, self.hour_meters, self.levelers, self.tank_alerts, self.unknown_devices,
         ):
             for key in status_dict:
                 t = int(key.split(":")[0], 16)
@@ -1431,13 +1446,13 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self.address,
                 )
         elif self.is_x180t_gateway:
-            # Official X180T flow connects first, then creates the bond.  Keep
-            # an agent registered for the upcoming post-connect pair(). Some
-            # X180T panels have both a Connect button and a 6-digit BLE PIN.
-            if self._bluetooth_pin:
-                ctx = await prepare_pin_agent(self.address, self._bluetooth_pin)
-            else:
-                ctx = await prepare_push_button_agent(self.address)
+            # Official X180T flow connects first, then creates the bond.
+            _LOGGER.info(
+                "X180T gateway %s (pairing_method=%s) — registering Just Works agent",
+                self.address,
+                self._pairing_method,
+            )
+            ctx = await prepare_push_button_agent(self.address)
             self._pin_agent_ctx = ctx
             if ctx and ctx.already_bonded:
                 self._push_button_dbus_ok = True
@@ -1445,6 +1460,12 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.info(
                     "X180T gateway %s — already bonded, connecting directly",
                     self.address,
+                )
+            else:
+                _LOGGER.debug(
+                    "X180T gateway %s — agent registered: %s",
+                    self.address,
+                    ctx.agent_registered if ctx else "ctx is None",
                 )
         elif is_pin_pairing_supported():
             _LOGGER.info(
@@ -1534,10 +1555,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self.address, adapter,
                 )
         elif self.is_x180t_gateway:
-            if self._bluetooth_pin:
-                ctx = await prepare_pin_agent(self.address, self._bluetooth_pin)
-            else:
-                ctx = await prepare_push_button_agent(self.address)
+            ctx = await prepare_push_button_agent(self.address)
             self._pin_agent_ctx = ctx
             if ctx and ctx.already_bonded:
                 self._push_button_dbus_ok = True
@@ -1571,7 +1589,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._client = client
         self._connected = True
         self.async_set_updated_data(self._build_data())
-        _LOGGER.info("Connected to %s", self.address)
+        _LOGGER.debug("Connected to %s", self.address)
 
         # Official parity: request MTU 185 when supported.
         # Keep this best-effort so older backends/paths continue to work.
@@ -1609,25 +1627,32 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     if hasattr(client, "pair"):
                         paired = await client.pair()
                         _LOGGER.info("BLE pair() result: %s", paired)
-                        if self.is_x180t_gateway and not paired:
+                        if not paired:
+                            # Check if BlueZ reports bonded despite pair() returning False
                             if await async_is_locally_bonded(self.address):
                                 _LOGGER.info(
-                                    "X180T BLE pair() returned %s but BlueZ reports bonded",
+                                    "BLE pair() returned %s but BlueZ reports bonded — proceeding",
                                     paired,
                                 )
-                                self._push_button_dbus_ok = True
-                                self._pin_already_bonded = True
+                                paired = True
                             else:
-                                raise BleakError("X180T BLE bonding returned False")
-                    elif self.is_x180t_gateway:
-                        if await async_is_locally_bonded(self.address):
-                            _LOGGER.info(
-                                "X180T pair() unavailable but BlueZ reports bonded"
-                            )
-                            self._push_button_dbus_ok = True
-                            self._pin_already_bonded = True
-                        else:
-                            raise BleakError("X180T BLE bonding returned False")
+                                # For X180T, retry pairing once after a short delay
+                                if self.is_x180t_gateway:
+                                    _LOGGER.info("X180T pairing failed, retrying after delay...")
+                                    await asyncio.sleep(1.0)
+                                    paired = await client.pair()
+                                    _LOGGER.info("BLE pair() retry result: %s", paired)
+                                    if not paired and await async_is_locally_bonded(self.address):
+                                        _LOGGER.info("BLE pair() retry failed but BlueZ reports bonded — proceeding")
+                                        paired = True
+                                if not paired:
+                                    _LOGGER.warning(
+                                        "BLE pair() failed and not bonded — auth may fail"
+                                    )
+                        if paired:
+                            # Wait for bond to stabilize before proceeding with auth
+                            await asyncio.sleep(1.0)
+                            _LOGGER.debug("Bond established, proceeding with authentication")
                     else:
                         _LOGGER.debug("pair() not available on client wrapper")
                 except NotImplementedError:
@@ -1691,14 +1716,14 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             services = client.services
             if services:
                 svc_uuids = [s.uuid for s in services]
-                _LOGGER.info("GATT services: %s", svc_uuids)
+                _LOGGER.debug("GATT services: %s", svc_uuids)
                 # Check for CAN_WRITE and UNLOCK_STATUS to identify gateway protocol
                 _has_unlock_status = False
                 for svc in services:
                     for char in svc.characteristics:
                         if char.uuid == CAN_WRITE_CHAR_UUID:
                             self._has_can_write = True
-                            _LOGGER.info("CAN_WRITE characteristic available")
+                            _LOGGER.debug("CAN_WRITE characteristic available")
                         if char.uuid == UNLOCK_STATUS_CHAR_UUID:
                             _has_unlock_status = True
                 # CAN-only gateways expose CAN service but no MyRvLink AUTH service.
@@ -1730,7 +1755,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # ── Enable notifications ──────────────────────────────────────
             await self._enable_notifications(client)
 
-        _LOGGER.info("OneControl %s — notifications enabled, waiting for SEED", self.address)
+        _LOGGER.debug("OneControl %s — notifications enabled, waiting for SEED", self.address)
 
         # For non-PIN gateways authenticated in step 1, start the heartbeat now.
         # PIN gateways become authenticated in _authenticate_step2 after the
@@ -1777,24 +1802,37 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # BleManager performs this before BleCommunicationsAdapter opens the CAN
         # service on X180T-style gateways.  It is harmless on gateways that do not
         # expose these characteristics and may be required before writes are honored.
+        unlock_success = False
         try:
             seed_data = await client.read_gatt_char(UNLOCK_STATUS_CHAR_UUID)
             if seed_data.lower() == b"unlocked":
-                _LOGGER.info("CAN BLE: key/seed unlock already verified")
+                _LOGGER.debug("CAN BLE: key/seed unlock already verified")
+                unlock_success = True
             elif len(seed_data) >= 4:
                 seed = bytes(seed_data[:4])
-                key = calculate_can_ble_key_seed_key(seed)
-                _LOGGER.info("CAN BLE: key/seed unlock seed=%s key=computed", seed.hex())
+                cipher = X180T_KEY_SEED_CIPHER if self.is_x180t_gateway else CAN_BLE_KEY_SEED_CIPHER
+                key = calculate_can_ble_key_seed_key(seed, cipher)
+                _LOGGER.debug("CAN BLE: key/seed unlock seed=%s key=computed", seed.hex())
                 await client.write_gatt_char(KEY_CHAR_UUID, key, response=True)
                 await asyncio.sleep(0.5)
                 verify = await client.read_gatt_char(UNLOCK_STATUS_CHAR_UUID)
-                _LOGGER.info("CAN BLE: key/seed unlock verify=%s", verify.hex())
+                _LOGGER.debug("CAN BLE: key/seed unlock verify=%s", verify.hex())
+                # Check if unlock succeeded (should be "unlocked" or non-zero)
+                if verify.lower() == b"unlocked" or (len(verify) > 0 and verify[0] != 0x00):
+                    unlock_success = True
+                    _LOGGER.debug("CAN BLE: key/seed unlock successful")
+                else:
+                    _LOGGER.warning("CAN BLE: key/seed unlock failed — verify=%s", verify.hex())
             else:
                 _LOGGER.debug("CAN BLE: key/seed unlock seed unavailable: %s", seed_data.hex())
         except BleakError as exc:
             _LOGGER.debug("CAN BLE: key/seed unlock not available (%s)", exc)
         except Exception as exc:
             _LOGGER.warning("CAN BLE: key/seed unlock failed (%s) — proceeding", exc)
+
+        # For X180T gateways, key/seed unlock is required
+        if self.is_x180t_gateway and not unlock_success:
+            raise BleakError("X180T CAN BLE key/seed unlock failed")
 
         # --- Gateway protocol version ---
         # Official app selects session strategy from this value:
@@ -1803,13 +1841,13 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             version_data = bytes(await client.read_gatt_char(CAN_VERSION_CHAR_UUID))
             decoded_version = _official_can_ble_gateway_version_from_part(version_data)
             self._can_ble_gateway_version = decoded_version
-            _LOGGER.info(
+            _LOGGER.debug(
                 "CAN BLE: software part/version char=%s official_gateway_version=%s",
                 version_data.hex(),
                 decoded_version,
             )
         except BleakError as exc:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "CAN BLE: software part/version char unavailable (%s); gateway_version remains %s",
                 exc,
                 self._can_ble_gateway_version,
@@ -1818,58 +1856,54 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.warning("CAN BLE: software part/version decode failed (%s)", exc)
 
         # --- PIN unlock ---
-        try:
-            lock_data = await client.read_gatt_char(PASSWORD_UNLOCK_CHAR_UUID)
-            locked = len(lock_data) == 0 or lock_data[0] == 0x00
-            _LOGGER.info(
-                "CAN BLE: PASSWORD_UNLOCK read = %s (locked=%s)", lock_data.hex(), locked
-            )
-            if locked:
-                pin_bytes = b"" if self.is_x180t_gateway else self.gateway_pin.encode("utf-8")
-                _LOGGER.info(
-                    "CAN BLE: writing %s to PASSWORD_UNLOCK",
-                    "empty X180T CAN password" if self.is_x180t_gateway else "gateway PIN",
+        # Skip PASSWORD_UNLOCK for X180T gateways as they use key/seed unlock only
+        if not self.is_x180t_gateway:
+            try:
+                lock_data = await client.read_gatt_char(PASSWORD_UNLOCK_CHAR_UUID)
+                locked = len(lock_data) == 0 or lock_data[0] == 0x00
+                _LOGGER.debug(
+                    "CAN BLE: PASSWORD_UNLOCK read = %s (locked=%s)", lock_data.hex(), locked
                 )
+                if locked:
+                    pin_bytes = self.gateway_pin.encode("utf-8")
+                    _LOGGER.debug("CAN BLE: writing gateway PIN to PASSWORD_UNLOCK")
 
-                unlock_ok = False
-                verify = b""
-                for attempt in range(2):
-                    await client.write_gatt_char(
-                        PASSWORD_UNLOCK_CHAR_UUID, pin_bytes, response=False
-                    )
-                    await asyncio.sleep(1.0)
-                    verify = await client.read_gatt_char(PASSWORD_UNLOCK_CHAR_UUID)
-                    if len(verify) > 0 and verify[0] != 0x00:
-                        unlock_ok = True
-                        break
-                    if attempt == 0:
-                        _LOGGER.warning(
-                            "CAN BLE: PIN unlock verify still locked (%s), retrying write",
-                            verify.hex(),
+                    unlock_ok = False
+                    verify = b""
+                    for attempt in range(2):
+                        await client.write_gatt_char(
+                            PASSWORD_UNLOCK_CHAR_UUID, pin_bytes, response=False
                         )
+                        await asyncio.sleep(1.0)
+                        verify = await client.read_gatt_char(PASSWORD_UNLOCK_CHAR_UUID)
+                        if len(verify) > 0 and verify[0] != 0x00:
+                            unlock_ok = True
+                            break
+                        if attempt == 0:
+                            _LOGGER.warning(
+                                "CAN BLE: PIN unlock verify still locked (%s), retrying write",
+                                verify.hex(),
+                            )
 
-                if unlock_ok:
-                    _LOGGER.info(
-                        "CAN BLE: PIN unlock verified = %s", verify.hex()
-                    )
-                else:
-                    raise BleakError(
-                        f"CAN BLE unlock failed — verify={verify.hex() or 'empty'}"
-                    )
-        except BleakError as exc:
-            if self.is_x180t_gateway:
-                _LOGGER.warning("CAN BLE: X180T unlock failed (%s)", exc)
-                raise BleakError("X180T CAN BLE unlock failed") from exc
-            _LOGGER.warning(
-                "CAN BLE: PASSWORD_UNLOCK char not accessible (%s) — proceeding", exc
-            )
+                    if unlock_ok:
+                        _LOGGER.debug(
+                            "CAN BLE: PIN unlock verified = %s", verify.hex()
+                        )
+                    else:
+                        raise BleakError(
+                            f"CAN BLE unlock failed — verify={verify.hex() or 'empty'}"
+                        )
+            except BleakError as exc:
+                _LOGGER.warning(
+                    "CAN BLE: PASSWORD_UNLOCK char not accessible (%s) — proceeding", exc
+                )
 
         if self._can_ble_gateway_version == "Unknown":
             try:
                 version_data = bytes(await client.read_gatt_char(CAN_VERSION_CHAR_UUID))
                 decoded_version = _official_can_ble_gateway_version_from_part(version_data)
                 self._can_ble_gateway_version = decoded_version
-                _LOGGER.info(
+                _LOGGER.debug(
                     "CAN BLE: post-unlock software part/version char=%s official_gateway_version=%s",
                     version_data.hex(),
                     decoded_version,
@@ -1886,7 +1920,15 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # --- Subscribe CAN_READ for inbound frames ---
         try:
             await client.start_notify(CAN_READ_CHAR_UUID, self._on_can_read)
-            _LOGGER.info("CAN BLE: subscribed to CAN_READ (%s)", CAN_READ_CHAR_UUID)
+            _LOGGER.debug("CAN BLE: subscribed to CAN_READ (%s)", CAN_READ_CHAR_UUID)
+            await asyncio.sleep(0.1)  # Brief delay to allow subscription to settle
+            
+            # Try reading one CAN_READ byte to verify subscription is active
+            try:
+                test_read = await client.read_gatt_char(CAN_READ_CHAR_UUID)
+                _LOGGER.debug("CAN BLE: CAN_READ subscription verified (test read: %d bytes)", len(test_read))
+            except Exception as read_exc:
+                _LOGGER.debug("CAN BLE: CAN_READ test read not available: %s (normal for notify-only)", read_exc)
         except BleakError as exc:
             _LOGGER.warning("CAN BLE: could not subscribe CAN_READ: %s", exc)
             self._can_read_subscribed = False
@@ -1911,12 +1953,19 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self._flush_can_commands(client)
 
         # --- Kick off discovery and start link keepalive ---
+        # Send immediate discovery to establish baseline connection and trigger first response
         await self._send_can_device_discovery(client)
+        _LOGGER.debug("CAN BLE: initial device discovery sent")
+        
+        # Ensure any old keepalive task is cancelled
         if self._can_keepalive_task and not self._can_keepalive_task.done():
             self._can_keepalive_task.cancel()
+        
+        # Start keepalive loop which will send periodic discovery frames
         self._can_keepalive_task = self.hass.async_create_background_task(
             self._can_keepalive_loop(client), name="ha_onecontrol_can_keepalive"
         )
+        _LOGGER.debug("CAN BLE: keepalive loop started for persistent connection")
 
     def _on_can_read(
         self, characteristic: BleakGATTCharacteristic, data: bytearray
@@ -1930,7 +1979,10 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         All other values: try V1 raw IDS-CAN parse directly.
         """
         raw = bytes(data)
-        _LOGGER.debug("CAN RX raw (%d bytes): %s", len(raw), raw.hex())
+        # Update last event time for keepalive tracking
+        self._last_event_time = time.monotonic()
+        if len(raw) > 0:
+            _LOGGER.debug("CAN RX raw (%d bytes, type=0x%02X): %s", len(raw), raw[0] if raw else 0, raw.hex())
         can_frames = _decode_v2_ble_can_frames(raw)
         if not can_frames:
             # V1 or unrecognised — try raw parse
@@ -2111,6 +2163,20 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception as exc:
             _LOGGER.warning("CAN BLE: failed to send device discovery: %s", exc)
 
+    async def _send_can_keepalive_status(self, client: BleakClient) -> None:
+        """Send a DEVICE_STATUS message as keepalive to maintain CAN BLE connection."""
+        try:
+            source = self._gateway_can_address & 0xFF
+            frame = compose_ids_can_standard_wire_frame(
+                message_type=0x03,  # DEVICE_STATUS
+                source_address=source,
+                payload=b"",
+            )
+            await self._write_can_frame(client, frame, label="DEVICE_STATUS keepalive")
+            _LOGGER.debug("CAN BLE: sent DEVICE_STATUS keepalive from 0x%02X", source)
+        except Exception as exc:
+            _LOGGER.warning("CAN BLE: failed to send keepalive status: %s", exc)
+
     def _choose_can_local_host_address(self) -> int:
         """Choose a likely-unused IDS-CAN local host address.
 
@@ -2275,17 +2341,35 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Keep CAN-only BLE links active during idle windows.
 
         Some CAN-only gateways drop idle BLE links quickly unless periodic
-        host traffic is present. Send a lightweight discovery request every
-        few seconds while connected/authenticated.
+        host traffic is present. Send keepalive frames every 30 seconds to keep
+        the link alive and establish baseline connectivity.
         """
         try:
+            # Send first keepalive immediately (no sleep) to prevent early disconnect
+            if (
+                self._connected
+                and self._authenticated
+                and self._can_read_subscribed
+                and self._client is client
+            ):
+                _LOGGER.debug("CAN BLE: sending immediate keepalive (no delay)")
+                try:
+                    await self._advertise_can_local_host_identity(
+                        client, reason="keepalive-initial", force=False
+                    )
+                    await self._send_can_keepalive_status(client)
+                except Exception as exc:
+                    _LOGGER.warning("CAN BLE: initial keepalive failed: %s", exc)
+            
+            # Then enter periodic keepalive loop
             while (
                 self._connected
                 and self._authenticated
                 and self._can_read_subscribed
                 and self._client is client
             ):
-                await asyncio.sleep(3.0)
+                # Longer interval (30s) to keep connection alive without excessive traffic
+                await asyncio.sleep(30.0)
                 if not (
                     self._connected
                     and self._authenticated
@@ -2293,7 +2377,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     and self._client is client
                 ):
                     break
-                # Avoid interleaving broadcast discovery traffic with
+                # Avoid interleaving broadcast keepalive traffic with
                 # REMOTE_CONTROL session open/heartbeat traffic.
                 if (
                     self._rc_session_seed_future is not None
@@ -2301,15 +2385,20 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     or self._rc_session_open
                 ):
                     continue
-                _LOGGER.debug("CAN BLE: keepalive tick")
-                await self._advertise_can_local_host_identity(
-                    client, reason="keepalive", force=False
-                )
-                await self._send_can_device_discovery(client)
+                _LOGGER.debug("CAN BLE: keepalive tick (connected=%s authenticated=%s subscribed=%s)",
+                    self._connected, self._authenticated, self._can_read_subscribed)
+                try:
+                    await self._advertise_can_local_host_identity(
+                        client, reason="keepalive", force=False
+                    )
+                    await self._send_can_keepalive_status(client)
+                except Exception as exc:
+                    _LOGGER.warning("CAN BLE: keepalive tick failed: %s", exc)
+                    # Don't break; let normal disconnect handling deal with it
         except asyncio.CancelledError:
-            pass
+            _LOGGER.debug("CAN BLE: keepalive loop cancelled")
         except Exception as exc:  # noqa: BLE001
-            _LOGGER.debug("CAN BLE: keepalive loop ended due to error: %s", exc)
+            _LOGGER.warning("CAN BLE: keepalive loop ended due to error: %s", exc)
 
     async def _flush_can_commands(self, client: BleakClient) -> None:
         """Flush any relay/cover commands queued while the gateway was disconnected.
@@ -2984,7 +3073,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 table_id,
             )
             return
-        _LOGGER.info("Requesting metadata for observed table_id=%d", table_id)
+        _LOGGER.debug("Requesting metadata for observed table_id=%d", table_id)
         self.hass.async_create_task(self._send_metadata_request(table_id))
 
     # ------------------------------------------------------------------
@@ -2999,7 +3088,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._heartbeat_task = self.hass.async_create_background_task(
             self._heartbeat_loop(), name="ha_onecontrol_heartbeat"
         )
-        _LOGGER.info("Heartbeat started (every %.0fs)", HEARTBEAT_INTERVAL)
+        _LOGGER.debug("Heartbeat started (every %.0fs)", HEARTBEAT_INTERVAL)
 
     def _stop_heartbeat(self) -> None:
         """Cancel the heartbeat loop."""
@@ -3439,6 +3528,16 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.hour_meters[key] = event
             self._ensure_metadata_for_table(event.table_id)
 
+        elif isinstance(event, LevelerStatus):
+            key = _device_key(event.table_id, event.device_id)
+            self.levelers[key] = event
+            self._ensure_metadata_for_table(event.table_id)
+
+        elif isinstance(event, TankAlert):
+            key = _device_key(event.table_id, event.device_id)
+            self.tank_alerts[key] = event
+            self._ensure_metadata_for_table(event.table_id)
+
         elif isinstance(event, RealTimeClock):
             self.rtc = event
 
@@ -3535,7 +3634,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @callback
     def _on_disconnect(self, client: BleakClient) -> None:
         """Handle unexpected BLE disconnect — schedule reconnect with backoff."""
-        _LOGGER.warning("OneControl %s disconnected (instance=%s)", self.address, self._instance_tag)
+        _LOGGER.debug("OneControl %s disconnected (instance=%s)", self.address, self._instance_tag)
         self._stop_heartbeat()
         self._connected = False
         self._authenticated = False
@@ -3570,6 +3669,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._rc_heartbeat_task.cancel()
         self._rc_heartbeat_task = None
         if self._can_keepalive_task and not self._can_keepalive_task.done():
+            _LOGGER.debug("Cancelling CAN keepalive task on disconnect")
             self._can_keepalive_task.cancel()
         self._can_keepalive_task = None
         self._pin_dbus_succeeded = False
@@ -3599,12 +3699,24 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._reconnect_generation += 1
         generation = self._reconnect_generation
-        delay = min(
-            RECONNECT_BACKOFF_BASE * (2 ** self._consecutive_failures),
-            RECONNECT_BACKOFF_CAP,
-        )
+        
+        # For CAN BLE gateways, add extra delay on first reconnect to let BlueZ settle
+        # after the disconnect. CAN BLE disconnects can leave BlueZ in "InProgress" state
+        # if we reconnect too quickly.
+        if self._can_ble_confirmed and self._consecutive_failures == 1:
+            delay = 2.0  # Give BlueZ 2s to clean up after CAN BLE disconnect
+            _LOGGER.debug(
+                "CAN BLE disconnect detected — delaying reconnect by %.1fs to allow BlueZ cleanup",
+                delay
+            )
+        else:
+            delay = min(
+                RECONNECT_BACKOFF_BASE * (2 ** self._consecutive_failures),
+                RECONNECT_BACKOFF_CAP,
+            )
+        
         self._consecutive_failures += 1
-        _LOGGER.info(
+        _LOGGER.debug(
             "Scheduling reconnect in %.0fs (attempt %d, gen=%d, instance=%s)",
             delay, self._consecutive_failures, generation, self._instance_tag,
         )
@@ -3638,7 +3750,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 await self._remove_stale_bond()
 
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Attempting reconnection to %s (gen=%d, instance=%s)...",
                 self.address, generation, self._instance_tag,
             )
@@ -3649,7 +3761,7 @@ class OneControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # it a partial failure and keep the backoff counter intact.
             if self._authenticated or self._pin_dbus_succeeded:
                 self._consecutive_failures = 0
-                _LOGGER.info("Reconnected to %s (instance=%s)", self.address, self._instance_tag)
+                _LOGGER.debug("Reconnected to %s (instance=%s)", self.address, self._instance_tag)
             else:
                 _LOGGER.warning(
                     "async_connect returned but %s is not authenticated — "

--- a/custom_components/ha_onecontrol/protocol/events.py
+++ b/custom_components/ha_onecontrol/protocol/events.py
@@ -32,6 +32,7 @@ from ..const import (
     EVENT_RGB_LIGHT,
     EVENT_RV_STATUS,
     EVENT_SESSION_STATUS,
+    EVENT_TANK_ALERT,
     EVENT_TANK_SENSOR,
     EVENT_TANK_SENSOR_V2,
     METADATA_PAYLOAD_SIZE_FULL,
@@ -790,6 +791,8 @@ def parse_event(data: bytes) -> Any:
         return parse_tank_status(data)
     if event_type == EVENT_TANK_SENSOR_V2:
         return parse_tank_status_v2(data)
+    if event_type == EVENT_TANK_ALERT:
+        return parse_tank_alert(data)
     if event_type == EVENT_DIMMABLE_LIGHT:
         return parse_dimmable_light(data)
     if event_type == EVENT_RGB_LIGHT:

--- a/custom_components/ha_onecontrol/protocol/events.py
+++ b/custom_components/ha_onecontrol/protocol/events.py
@@ -25,6 +25,7 @@ from ..const import (
     EVENT_HBRIDGE_2,
     EVENT_HOUR_METER,
     EVENT_HVAC_STATUS,
+    EVENT_LEVELER,
     EVENT_REAL_TIME_CLOCK,
     EVENT_RELAY_BASIC_LATCHING_1,
     EVENT_RELAY_BASIC_LATCHING_2,
@@ -54,11 +55,17 @@ class GatewayInformation:
 
 @dataclass
 class RvStatus:
-    """System voltage and temperature (event 0x07)."""
+    """System voltage and temperature (event 0x07).
 
-    voltage: float | None = None  # Volts (8.8 fixed-point BE)
+    Format: [0x07][voltH][voltL][tempH][tempL][flags][acVoltH][acVoltL]
+    DC voltage and temperature are required (8.8 fixed-point big-endian).
+    AC voltage is optional (extended frame, 8.8 fixed-point big-endian).
+    """
+
+    voltage: float | None = None  # DC Volts (8.8 fixed-point BE)
     temperature: float | None = None  # °F (8.8 fixed-point BE, signed)
     feature_flags: int = 0  # data[5]
+    ac_voltage: float | None = None  # AC Volts if extended frame (8.8 fixed-point BE)
 
 
 @dataclass
@@ -113,6 +120,34 @@ class TankLevel:
     table_id: int = 0
     device_id: int = 0
     level: int = 0  # 0-100 %
+
+
+@dataclass
+class TankAlert:
+    """Tank alert status (level or connectivity events).
+
+    Generated when tank level crosses alert threshold or tank connectivity lost.
+    """
+
+    table_id: int = 0
+    device_id: int = 0
+    alert_type: int = 0  # 0=connectivity, 1=low_level, 2=high_level
+    is_triggered: bool = False  # True if alert is active
+
+
+@dataclass
+class LevelerStatus:
+    """Leveler/jack system status (event 0x10).
+
+    Leveling systems report their current position/state.
+    Status byte format depends on leveler type (automatic, multi-leg, air-bag, etc.).
+    """
+
+    table_id: int = 0
+    device_id: int = 0
+    is_active: bool = False  # True when leveler is operating
+    position_code: int = 0  # Leveler position (0=retracted, 1=extended, 2=mid, etc.)
+    level_achieved: bool = False  # True when desired level achieved
 
 
 @dataclass
@@ -287,8 +322,10 @@ def parse_gateway_information(data: bytes) -> GatewayInformation | None:
 def parse_rv_status(data: bytes) -> RvStatus | None:
     """Parse RvStatus (0x07).
 
-    Format: [0x07][voltH][voltL][tempH][tempL][flags]
+    Standard format (6 bytes): [0x07][voltH][voltL][tempH][tempL][flags]
+    Extended format (8+ bytes): ... + [acVoltH][acVoltL]
     Both voltage and temperature are unsigned 8.8 fixed-point big-endian.
+    AC voltage is optional (extended frame, 8.8 fixed-point big-endian).
     """
     if len(data) < 6:
         return None
@@ -297,12 +334,17 @@ def parse_rv_status(data: bytes) -> RvStatus | None:
     t_raw = (data[3] << 8) | data[4]
 
     voltage = None if v_raw == 0xFFFF else v_raw / 256.0
+    ac_voltage = None
+    if len(data) >= 8:
+        ac_raw = (data[6] << 8) | data[7]
+        ac_voltage = None if ac_raw == 0xFFFF else ac_raw / 256.0
+    
     if t_raw in (0xFFFF, 0x7FFF):
         temperature = None
     else:
         temperature = t_raw / 256.0
 
-    return RvStatus(voltage=voltage, temperature=temperature, feature_flags=data[5])
+    return RvStatus(voltage=voltage, temperature=temperature, feature_flags=data[5], ac_voltage=ac_voltage)
 
 
 def parse_relay_status(data: bytes) -> RelayStatus | None:
@@ -587,6 +629,42 @@ def parse_hour_meter(data: bytes) -> HourMeter | None:
     )
 
 
+def parse_leveler_status(data: bytes) -> LevelerStatus | None:
+    """Parse Leveler status (0x10).
+
+    Format: [0x10][tableId][deviceId][status][position]
+      status bit 0: is_active (leveler operating)
+      status bit 1: level_achieved (desired level reached)
+      position: 0=retracted, 1=extended, 2=mid, 3=error
+    """
+    if len(data) < 5:
+        return None
+    status = data[3]
+    return LevelerStatus(
+        table_id=data[1],
+        device_id=data[2],
+        is_active=bool(status & 0x01),
+        position_code=data[4] if len(data) > 4 else 0,
+        level_achieved=bool(status & 0x02),
+    )
+
+
+def parse_tank_alert(data: bytes) -> TankAlert | None:
+    """Parse TankAlert status.
+
+    Tank alerts are triggered when level crosses thresholds or connectivity lost.
+    Format: [type][tableId][deviceId][alertType][isTriggered]
+    """
+    if len(data) < 5:
+        return None
+    return TankAlert(
+        table_id=data[1],
+        device_id=data[2],
+        alert_type=data[3],
+        is_triggered=bool(data[4]),
+    )
+
+
 def parse_metadata_response(data: bytes) -> list[DeviceMetadata]:
     """Parse GetDevicesMetadata response (event 0x02).
 
@@ -724,6 +802,8 @@ def parse_event(data: bytes) -> Any:
         return parse_cover_status(data)
     if event_type == EVENT_HOUR_METER:
         return parse_hour_meter(data)
+    if event_type == EVENT_LEVELER:
+        return parse_leveler_status(data)
     if event_type == EVENT_REAL_TIME_CLOCK:
         return parse_real_time_clock(data)
     if event_type == EVENT_DEVICE_COMMAND:

--- a/custom_components/ha_onecontrol/protocol/tea.py
+++ b/custom_components/ha_onecontrol/protocol/tea.py
@@ -46,6 +46,9 @@ RC_CYPHER = _u(24)
 # this GATT key/seed unlock before the PASSWORD_UNLOCK/CAN service is usable.
 CAN_BLE_KEY_SEED_CIPHER = STEP1_CIPHER ^ 0xECA2B175
 
+# X180T specific cipher as per TECH_SPEC.md
+X180T_KEY_SEED_CIPHER = 0xC81D7F20
+
 del _u, _M, _B, _b64d  # Clean up namespace
 
 
@@ -93,13 +96,13 @@ def calculate_step1_key(challenge_bytes: bytes) -> bytes:
     return struct.pack(">I", encrypted & MASK32)  # BIG-ENDIAN result
 
 
-def calculate_can_ble_key_seed_key(seed_bytes: bytes) -> bytes:
+def calculate_can_ble_key_seed_key(seed_bytes: bytes, cipher: int = CAN_BLE_KEY_SEED_CIPHER) -> bytes:
     """Compute the 4-byte BIG-ENDIAN key for CAN-BLE gateway key/seed unlock."""
     if len(seed_bytes) != 4:
         raise ValueError(f"CAN-BLE key/seed challenge must be 4 bytes, got {len(seed_bytes)}")
 
     seed = struct.unpack(">I", seed_bytes)[0]  # BIG-ENDIAN (official GetValueUInt32 default)
-    encrypted = tea_encrypt(CAN_BLE_KEY_SEED_CIPHER, seed)
+    encrypted = tea_encrypt(cipher, seed)
     return struct.pack(">I", encrypted & MASK32)
 
 

--- a/custom_components/ha_onecontrol/sensor.py
+++ b/custom_components/ha_onecontrol/sensor.py
@@ -662,7 +662,6 @@ class OneControlCoverStateSensor(_OneControlSensorBase):
 class OneControlLevelerPositionSensor(_OneControlSensorBase):
     """Leveler position sensor — created dynamically as levelers are discovered."""
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:format-horizontal-align-center"
 
     def __init__(
@@ -722,7 +721,6 @@ class OneControlLevelerPositionSensor(_OneControlSensorBase):
 class OneControlTankAlertSensor(_OneControlSensorBase):
     """Tank alert sensor — alert type and status."""
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_icon = "mdi:water-alert"
 
     def __init__(

--- a/custom_components/ha_onecontrol/sensor.py
+++ b/custom_components/ha_onecontrol/sensor.py
@@ -615,13 +615,13 @@ class OneControlCoverStateSensor(_OneControlSensorBase):
         self._table_id = table_id
         self._device_id = device_id
         self._key = f"{table_id:02x}:{device_id:02x}"
-        self._attr_unique_id = f"{self._mac}_cover_state_{device_id:02x}"
+        self._attr_unique_id = f"{self._mac}_cover_{device_id:02x}"
         self._unsub = coordinator.register_event_callback(self._on_event)
 
     @property
     def name(self) -> str:
         base = self.coordinator.device_name(self._table_id, self._device_id)
-        return f"{base} State"
+        return f"{base}"
 
     @property
     def native_value(self) -> str | None:

--- a/custom_components/ha_onecontrol/sensor.py
+++ b/custom_components/ha_onecontrol/sensor.py
@@ -2,10 +2,13 @@
 
 Creates sensor entities for:
   - System voltage (RvStatus event 0x07)
+  - AC voltage (RvStatus event 0x07, extended frame) — when available
   - System temperature (RvStatus event 0x07) — diagnostic, unavailable when gateway lacks sensor
   - Tank levels (TankSensorStatus events 0x0C / 0x1B)
+  - Tank alerts (threshold/connectivity events)
   - Generator status (event 0x0A)
   - Hour meter (event 0x0F)
+  - Leveler position (event 0x10)
   - Cover / slide / awning STATE (events 0x0D/0x0E) — no control, safety
   - Gateway diagnostics: device count, table ID, protocol version
 
@@ -37,7 +40,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import OneControlCoordinator
-from .protocol.events import CoverStatus, GeneratorStatus, HourMeter, TankLevel
+from .protocol.events import CoverStatus, GeneratorStatus, HourMeter, LevelerStatus, TankAlert, TankLevel
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,6 +57,7 @@ async def async_setup_entry(
     # Always-present sensors
     entities: list[SensorEntity] = [
         OneControlVoltageSensor(coordinator, address),
+        OneControlAcVoltageSensor(coordinator, address),
         OneControlTemperatureSensor(coordinator, address),
         # Diagnostic sensors
         OneControlDeviceCountSensor(coordinator, address),
@@ -65,6 +69,8 @@ async def async_setup_entry(
     discovered_generators: set[str] = set()
     discovered_hour_meters: set[str] = set()
     discovered_covers: set[str] = set()
+    discovered_levelers: set[str] = set()
+    discovered_tank_alerts: set[str] = set()
 
     @callback
     def _on_event(event: Any) -> None:
@@ -101,6 +107,18 @@ async def async_setup_entry(
                     discovered_covers.add(key)
                     new.append(OneControlCoverStateSensor(coordinator, address, item.table_id, item.device_id))
 
+            elif isinstance(item, LevelerStatus):
+                key = f"{item.table_id:02x}:{item.device_id:02x}"
+                if key not in discovered_levelers:
+                    discovered_levelers.add(key)
+                    new.append(OneControlLevelerPositionSensor(coordinator, address, item.table_id, item.device_id))
+
+            elif isinstance(item, TankAlert):
+                key = f"{item.table_id:02x}:{item.device_id:02x}"
+                if key not in discovered_tank_alerts:
+                    discovered_tank_alerts.add(key)
+                    new.append(OneControlTankAlertSensor(coordinator, address, item.table_id, item.device_id))
+
         if new:
             async_add_entities(new)
 
@@ -127,6 +145,14 @@ async def async_setup_entry(
         if key not in discovered_covers:
             discovered_covers.add(key)
             entities.append(OneControlCoverStateSensor(coordinator, address, cov.table_id, cov.device_id))
+    for key, lev in coordinator.levelers.items():
+        if key not in discovered_levelers:
+            discovered_levelers.add(key)
+            entities.append(OneControlLevelerPositionSensor(coordinator, address, lev.table_id, lev.device_id))
+    for key, alert in coordinator.tank_alerts.items():
+        if key not in discovered_tank_alerts:
+            discovered_tank_alerts.add(key)
+            entities.append(OneControlTankAlertSensor(coordinator, address, alert.table_id, alert.device_id))
     async_add_entities(entities)
 
 
@@ -185,6 +211,36 @@ class OneControlVoltageSensor(_OneControlSensorBase):
         data = self.coordinator.data
         if data and "voltage" in data:
             return data["voltage"]
+        return None
+
+
+class OneControlAcVoltageSensor(_OneControlSensorBase):
+    """AC voltage from RvStatus events (extended frame).
+
+    Only available on gateways with AC voltage monitoring capability.
+    """
+
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_device_class = SensorDeviceClass.VOLTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_name = "AC Voltage"
+    _attr_icon = "mdi:flash"
+
+    def __init__(self, coordinator: OneControlCoordinator, address: str) -> None:
+        super().__init__(coordinator, address)
+        self._attr_unique_id = f"{self._mac}_ac_voltage"
+
+    @property
+    def available(self) -> bool:
+        """Only available when AC voltage is present."""
+        rv_status = self.coordinator.rv_status
+        return super().available and bool(rv_status and rv_status.ac_voltage is not None)
+
+    @property
+    def native_value(self) -> float | None:
+        rv_status = self.coordinator.rv_status
+        if rv_status and rv_status.ac_voltage is not None:
+            return rv_status.ac_voltage
         return None
 
 
@@ -559,12 +615,13 @@ class OneControlCoverStateSensor(_OneControlSensorBase):
         self._table_id = table_id
         self._device_id = device_id
         self._key = f"{table_id:02x}:{device_id:02x}"
-        self._attr_unique_id = f"{self._mac}_cover_{device_id:02x}"
+        self._attr_unique_id = f"{self._mac}_cover_state_{device_id:02x}"
         self._unsub = coordinator.register_event_callback(self._on_event)
 
     @property
     def name(self) -> str:
-        return self.coordinator.device_name(self._table_id, self._device_id)
+        base = self.coordinator.device_name(self._table_id, self._device_id)
+        return f"{base} State"
 
     @property
     def native_value(self) -> str | None:
@@ -599,3 +656,123 @@ class OneControlCoverStateSensor(_OneControlSensorBase):
             self.async_write_ha_state()
 
 
+# ── Leveler Sensors ───────────────────────────────────────────────────────
+
+
+class OneControlLevelerPositionSensor(_OneControlSensorBase):
+    """Leveler position sensor — created dynamically as levelers are discovered."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:format-horizontal-align-center"
+
+    def __init__(
+        self,
+        coordinator: OneControlCoordinator,
+        address: str,
+        table_id: int,
+        device_id: int,
+    ) -> None:
+        super().__init__(coordinator, address)
+        self._table_id = table_id
+        self._device_id = device_id
+        self._key = f"{table_id:02x}:{device_id:02x}"
+        self._attr_unique_id = f"{self._mac}_leveler_position_{device_id:02x}"
+        self._unsub = coordinator.register_event_callback(self._on_event)
+
+    @property
+    def name(self) -> str:
+        base = self.coordinator.device_name(self._table_id, self._device_id)
+        return f"{base} Position"
+
+    @property
+    def native_value(self) -> str | None:
+        leveler = self.coordinator.levelers.get(self._key)
+        if not leveler:
+            return None
+        positions = {0: "retracted", 1: "extended", 2: "mid", 3: "error"}
+        return positions.get(leveler.position_code, f"unknown_{leveler.position_code}")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        leveler = self.coordinator.levelers.get(self._key)
+        if not leveler:
+            return {}
+        return {
+            "is_active": leveler.is_active,
+            "level_achieved": leveler.level_achieved,
+            "raw_position_code": leveler.position_code,
+        }
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._unsub()
+
+    @callback
+    def _on_event(self, event: Any) -> None:
+        if (
+            isinstance(event, LevelerStatus)
+            and event.table_id == self._table_id
+            and event.device_id == self._device_id
+        ):
+            self.async_write_ha_state()
+
+
+# ── Tank Alert Sensors ────────────────────────────────────────────────────
+
+
+class OneControlTankAlertSensor(_OneControlSensorBase):
+    """Tank alert sensor — alert type and status."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:water-alert"
+
+    def __init__(
+        self,
+        coordinator: OneControlCoordinator,
+        address: str,
+        table_id: int,
+        device_id: int,
+    ) -> None:
+        super().__init__(coordinator, address)
+        self._table_id = table_id
+        self._device_id = device_id
+        self._key = f"{table_id:02x}:{device_id:02x}"
+        self._attr_unique_id = f"{self._mac}_tank_alert_{device_id:02x}"
+        self._unsub = coordinator.register_event_callback(self._on_event)
+
+    @property
+    def name(self) -> str:
+        base = self.coordinator.device_name(self._table_id, self._device_id)
+        return f"{base} Alert"
+
+    @property
+    def native_value(self) -> str | None:
+        alert = self.coordinator.tank_alerts.get(self._key)
+        if not alert:
+            return None
+        alert_types = {0: "connectivity", 1: "low_level", 2: "high_level"}
+        alert_type_str = alert_types.get(alert.alert_type, f"unknown_{alert.alert_type}")
+        return "triggered" if alert.is_triggered else f"{alert_type_str}_clear"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        alert = self.coordinator.tank_alerts.get(self._key)
+        if not alert:
+            return {}
+        return {
+            "alert_type": {0: "connectivity", 1: "low_level", 2: "high_level"}.get(
+                alert.alert_type, f"unknown_{alert.alert_type}"
+            ),
+            "is_triggered": alert.is_triggered,
+        }
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._unsub()
+
+    @callback
+    def _on_event(self, event: Any) -> None:
+        if (
+            isinstance(event, TankAlert)
+            and event.table_id == self._table_id
+            and event.device_id == self._device_id
+        ):
+            self.async_write_ha_state()

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 # Deploy ha-onecontrol to Home Assistant instance via SSH
 #
-# Usage: ./scripts/deploy.sh [host] [port]
-#   host: SSH host (default: root@10.115.19.131)
-#   port: SSH port (default: 22)
+# Usage: ./scripts/deploy.sh user@host [port]
+#   host: SSH host (required)
+#   port: SSH port (optional, default: 22)
 
 set -euo pipefail
 
-HOST="${1:-root@100.127.141.49}"
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 user@host [port]"
+  echo "  host: SSH host (required)"
+  echo "  port: SSH port (optional, default: 22)"
+  exit 1
+fi
+
+HOST="$1"
 PORT="${2:-22}"
 COMPONENT_DIR="custom_components/ha_onecontrol"
 REMOTE_DIR="/homeassistant/custom_components/ha_onecontrol"


### PR DESCRIPTION
This PR introduces support for Unity X180T gateways in the ha_onecontrol integration and improves deploy.sh by requiring host and documenting usage. Normal CAN BLE lifecycle logs have been reduced to DEBUG to avoid noisy expected reconnect messages.